### PR TITLE
ci(release): add tag-triggered Windows release workflow (issue #4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - 'v[0-9]*.[0-9]*.[0-9]*'
 
 permissions:
   contents: write
@@ -37,6 +37,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
 
       - name: Build portable bundle + ZIP
         shell: pwsh
@@ -46,4 +48,5 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
           files: dist/wispy-${{ github.ref_name }}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,16 +10,40 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
+    timeout-minutes: 30
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+
+      - name: Version sanity check
+        shell: pwsh
+        run: |
+          $tag = "${{ github.ref_name }}"
+          $tagVersion = $tag -replace '^v', ''
+          $tomlContent = Get-Content pyproject.toml -Raw
+          if ($tomlContent -match 'version\s*=\s*"([^"]+)"') {
+              $tomlVersion = $Matches[1]
+          } else {
+              Write-Error "Could not read version from pyproject.toml"
+              exit 1
+          }
+          if ($tagVersion -ne $tomlVersion) {
+              Write-Error "Tag '$tag' does not match pyproject.toml version '$tomlVersion'. Bump pyproject.toml and re-tag."
+              exit 1
+          }
+          Write-Host "Version OK: $tomlVersion"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build portable bundle + ZIP
+        shell: pwsh
+        run: powershell -ExecutionPolicy Bypass -File build/build.ps1 -CreateZip
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          files: dist/wispy-${{ github.ref_name }}.zip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,11 @@ Erster Start laedt Whisper-Modell herunter (~1.6 GB nach `<repo-root>/models/lar
 
 ## Release
 
-Kanonische Version lebt in `pyproject.toml`; `__version__` wird via `importlib.metadata` daraus abgeleitet. Release-Ablauf siehe `CONTRIBUTING.md` (Bump → Tag → `build.ps1 -CreateZip` → `gh release create`).
+Kanonische Version lebt in `pyproject.toml`; `__version__` wird via `importlib.metadata` daraus abgeleitet.
+
+**Kanonischer Release-Weg (Tag-Push → CI)**: Version in `pyproject.toml` bumpen → committen → `git tag vX.Y.Z && git push origin main --tags`. Der Workflow `.github/workflows/release.yml` baut automatisch auf `windows-latest`, packt `wispy-vX.Y.Z.zip` und erstellt den GitHub-Release mit generierten Release Notes.
+
+**Manueller Fallback**: `build.ps1 -CreateZip` → `gh release create` (Details in `CONTRIBUTING.md`).
 
 ## Umsetzungsstatus
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,44 +50,47 @@ Use [Conventional Commits](https://www.conventionalcommits.org/):
 
 The canonical version lives **exclusively** in `pyproject.toml` (`version = "X.Y.Z"`).
 `src/wispy/__init__.py` derives `__version__` from it at runtime via `importlib.metadata`.
-Tag schema: `vX.Y.Z` (with "v" prefix). Current line: `version = "X.Y.Z"` in `[project]`.
+Tag schema: `vX.Y.Z` (with "v" prefix).
 
-### Steps (run on Windows — the build requires PyInstaller + CUDA DLLs)
+### Kanonischer Weg: Tag-Push → GitHub Actions (empfohlen)
 
-1. **Bump the version** in `pyproject.toml` (the single source of truth):
+1. **Version bumpen** in `pyproject.toml`:
    ```toml
    version = "0.3.0"
    ```
 
-2. **Commit** the version bump:
+2. **Commit** des Version-Bumps:
    ```powershell
    git add pyproject.toml
    git commit -m "chore: bump version to 0.3.0"
    ```
 
-3. **Tag** the commit:
+3. **Tag setzen und pushen** — CI übernimmt den Rest:
    ```powershell
    git tag v0.3.0
    git push origin main --tags
    ```
 
-4. **Build the bundle and create the ZIP**:
+Der Workflow `.github/workflows/release.yml` prüft automatisch, dass Tag und `pyproject.toml`-Version übereinstimmen, baut das portable Bundle auf `windows-latest` via `build/build.ps1 -CreateZip` und veröffentlicht `wispy-v0.3.0.zip` als GitHub-Release-Asset mit automatisch generierten Release Notes.
+
+### Manueller Fallback (falls CI nicht verfügbar)
+
+> Erfordert eine Windows-Maschine mit `uv`, CUDA 12.x und `gh` installiert.
+
+Nach Schritt 3 oben:
+
+4. **Bundle bauen und ZIP erstellen**:
    ```powershell
    .\build\build.ps1 -CreateZip
    ```
-   This produces `dist\wispy-v0.3.0.zip` (reads the version from `pyproject.toml` automatically).
+   Erzeugt `dist\wispy-v0.3.0.zip` (Version wird automatisch aus `pyproject.toml` gelesen).
 
-5. **Create the GitHub Release** and attach the ZIP:
+5. **GitHub Release erstellen** und ZIP anhängen:
    ```powershell
    gh release create v0.3.0 dist\wispy-v0.3.0.zip `
        --title "wispy v0.3.0" `
        --notes "Brief description of what changed."
    ```
-
-The release is now live on GitHub with the versioned ZIP as an asset.
-
-> **Note:** Steps 4 and 5 require a Windows machine with `uv`, CUDA 12.x, and `gh` installed.
-> Automation via GitHub Actions is planned for Phase 2 (separate issue).
 
 ## Code of Conduct
 


### PR DESCRIPTION
Closes #4

## Summary

Implements Phase 2 of the release process: tag-push triggers a CI build on `windows-latest` that produces the portable bundle ZIP and publishes it as a GitHub Release asset with auto-generated release notes.

## Files changed

- `.github/workflows/release.yml` — new tag-triggered workflow (replaces the old minimal release.yml).
- `CLAUDE.md`, `CONTRIBUTING.md` — documentation updates: tag-push as canonical release path, manual `build.ps1` flow as fallback. (From the bot's autonomous run.)

## Notes

The workflow file was committed manually via a personal access token with `workflow` scope. The GitHub App used by the autonomous Claude workflow cannot edit `.github/workflows/*` files — this is a GitHub-platform limitation on App tokens, not a repo configuration issue.

The bot produced the workflow content during run https://github.com/mka-codelake/wispy/actions/runs/25250512966 and documented it in the issue comment thread.

## Test plan

- [ ] Reviewer workflow runs against this PR
- [ ] After merge: `git tag v0.2.1-rc1 && git push origin --tags` → release.yml triggers, builds bundle, publishes release with `wispy-v0.2.1-rc1.zip`
- [ ] Cleanup the rc release after smoke test if not desired