### PR TITLE
docs(release): add inline comment explaining prerelease detection logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,5 +56,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+          # tags containing a hyphen (e.g. v1.0.0-rc1) are treated as pre-release; stable tags have none
           prerelease: ${{ contains(github.ref_name, '-') }}
           files: dist/wispy-${{ github.ref_name }}.zip


### PR DESCRIPTION
Closes #17

Auto-created by claude-dispatcher. Plan, file list, and test notes are in the latest comment on issue #17 and in commit messages on this branch.

PR is opened as **Draft**. The reviewer workflow will mark it **Ready for review** once it issues an APPROVED verdict.